### PR TITLE
increase memory and timeout for ems-report lambda

### DIFF
--- a/ems-report/cloudformation.yaml
+++ b/ems-report/cloudformation.yaml
@@ -92,10 +92,10 @@ Resources:
               }
             }
       Handler: main.lambda_handler
-      MemorySize: 128
+      MemorySize: 1024
       Role: !GetAtt Role.Arn
       Runtime: python3.8
-      Timeout: 300
+      Timeout: 900
 
   Schedule:
     Type: AWS::Events::Rule


### PR DESCRIPTION
High traffic day on 10/13/2020 resulted in the ems-report lambda not being able to process all the data before it's 5 minute timeout.  This attempts to resolve the issue by provisioning more time and memory.

```
2020-10-13T22:18:36.011-08:00 END RequestId: 6e37647a-851e-4f47-9e0d-71c8956ea332
2020-10-13T22:18:36.011-08:00 REPORT RequestId: 6e37647a-851e-4f47-9e0d-71c8956ea332 Duration: 302062.00 ms Billed Duration: 300000 ms Memory Size: 128 MB Max Memory Used: 128 MB
2020-10-13T22:18:36.011-08:00 2020-10-14T06:18:36.010Z 6e37647a-851e-4f47-9e0d-71c8956ea332 Task timed out after 302.06 seconds
```