### PR TITLE
update ems-report permissions for elasticsearch 7.10

### DIFF
--- a/ems-report/cloudformation.yaml
+++ b/ems-report/cloudformation.yaml
@@ -67,7 +67,7 @@ Resources:
             Resource: !Sub "${DomainArn}/${IndexName}/_search*"
           - Effect: Allow
             Action:
-            - es:ESHttpGet
+            - es:ESHttpPost
             - es:ESHttpDelete
             Resource: !Sub "${DomainArn}/_search/scroll*"
 

--- a/ems-report/cloudformation.yaml
+++ b/ems-report/cloudformation.yaml
@@ -63,7 +63,7 @@ Resources:
             Resource: !Sub "arn:aws:s3:::${OutputBucket}/${OutputPrefix}*"
           - Effect: Allow
             Action:
-            - es:ESHttpGet
+            - es:ESHttpPost
             Resource: !Sub "${DomainArn}/${IndexName}/_search*"
           - Effect: Allow
             Action:


### PR DESCRIPTION
We're using elasticsearch.helpers.scan at https://github.com/asfadmin/grfn-logging/blob/test/ems-report/src/ems_report.py#L62

Scan 7.10 calls elasticsearch.client.search and elasticsearch.client.scroll in https://github.com/elastic/elasticsearch-py/blob/7.10/elasticsearch/helpers/actions.py#L466

client.search makes a POST request at https://github.com/elastic/elasticsearch-py/blob/7.10/elasticsearch/client/__init__.py#L1657