### PR TITLE
ignore upgrades for `elasticsearch>7`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       interval: weekly
     labels:
       - bumpless
+    ignore:
+      # pin to elasticsearch v7: https://github.com/asfadmin/grfn-logging/issues/81
+      - dependency-name: elasticsearch
+        versions: '>7'
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Fixes https://github.com/asfadmin/grfn-logging/issues/81